### PR TITLE
Update imports to use .js extension instead of .ts

### DIFF
--- a/vcf-nav.ts
+++ b/vcf-nav.ts
@@ -1,2 +1,2 @@
-import './src/vcf-nav.ts';
-import './src/vcf-nav-item.ts';
+import './src/vcf-nav.js';
+import './src/vcf-nav-item.js';


### PR DESCRIPTION
## Description

This should resolve the following error:

```
✘ [ERROR] Could not resolve "./src/vcf-nav.ts"

    node_modules/@vaadin-component-factory/vcf-nav/vcf-nav.js:1:7:
      1 │ import './src/vcf-nav.ts';
        ╵        ~~~~~~~~~~~~~~~~~~

✘ [ERROR] Could not resolve "./src/vcf-nav-item.ts"

    node_modules/@vaadin-component-factory/vcf-nav/vcf-nav.js:2:7:
      2 │ import './src/vcf-nav-item.ts';
        ╵        ~~~~~~~~~~~~~~~~~~~~~~~
```

## Type of change

- Bugfix